### PR TITLE
Add Staples, Zehrs, Canada Computers, and System76

### DIFF
--- a/js/site-list.js
+++ b/js/site-list.js
@@ -15,6 +15,7 @@ const siteList = [
     'amazon.co.uk',
     'bestbuy.com',
     'bhphotovideo.com',
+    'canadacomputers.com',
     'ebay.com',
     'ebay.com.au',
     'ebay.at',
@@ -33,7 +34,10 @@ const siteList = [
     'etsy.com',
     'walmart.com',
     'maycs.com',
+    'staples.com',
+    'staples.ca',
     'swappa.com',
+    'system76.com',
     'target.com',
     'aliexpress.com',
     'newegg.com',
@@ -41,5 +45,6 @@ const siteList = [
     'gearbest.com',
     'flipkart.com',
     'qvc.com',
-    'shopping.google.com'
+    'shopping.google.com',
+    'zehrs.ca'
 ]


### PR DESCRIPTION
- Staples: office supply store (moderately popular)
- Zehrs: Grocery store chain on Ontario (probably about 30% of ontariens use zehrs)
- Canada Computers: Canadian computer store (a little popular)
- System76: Linux computers (well-known in the Linux community)

Feel free to accept or reject this PR. I'm just adding a few stores :slightly_smiling_face: