### PR TITLE
Allow popup toggle to work without page reload + update music volume while dragging

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -57,8 +57,10 @@ chrome.storage.onChanged.addListener(function (changes, area) {
     }
     if (changes.musicEnabled) {
         musicEnabled = changes.musicEnabled.newValue
-        if (!changes.musicEnabled) {
+        if (!musicEnabled) {
             themeAudio.src = ''
+        } else {
+            chrome.tabs.query({active: true, lastFocusedWindow: true}, checkMusic);
         }
     }
     if (changes.music) {

--- a/js/popup.js
+++ b/js/popup.js
@@ -12,11 +12,13 @@ document.querySelector('#music-picker').addEventListener('change', function () {
 })
 
 // Save volume
-document.querySelector('#music-volume').addEventListener('change', function () {
+function updateVolume() {
     chrome.storage.local.set({
         volume: document.querySelector('#music-volume').value / 100
     })
-})
+}
+document.querySelector('#music-volume').addEventListener('change', updateVolume)
+document.querySelector('#music-volume').addEventListener('input', updateVolume)
 
 // Get stored settings
 chrome.storage.local.get({

--- a/settings.html
+++ b/settings.html
@@ -29,7 +29,6 @@
     <div class="container-fluid">
 
         <button class="btn btn-sm btn-wii mt-3 w-100" id="music-toggle">...</button>
-        <div class="form-text">You may need to switch tabs for this to take effect.</div>
 
         <label for="music-picker" class="mt-2 form-label">Music picker</label>
         <select id="music-picker" multiple size="5" class="form-select w-100" multiple>


### PR DESCRIPTION
Added functionality which allows the 'Turn background music on/off' toggle to work without the need to reload the page / switch tabs.